### PR TITLE
Replace mode selector with dropdown and dynamic data loading

### DIFF
--- a/src/components/hvac/ModeSelector.tsx
+++ b/src/components/hvac/ModeSelector.tsx
@@ -88,7 +88,7 @@ export function ModeSelector({ value, onChange }: ModeSelectorProps) {
               {`${opt.nome} (${Math.round(opt.valor * 100)}%)`}
             </SelectItem>
           ))}
-          <SelectItem value="maximo">Capacidade Máxima</SelectItem>
+          <SelectItem value="maximo"><span className="sr-only">Capacidade Máxima</span></SelectItem>
         </SelectContent>
       </Select>
     </HVACCard>

--- a/src/components/hvac/ModeSelector.tsx
+++ b/src/components/hvac/ModeSelector.tsx
@@ -1,60 +1,96 @@
-import { Label } from "@/components/ui/label"
+import { useEffect, useMemo, useState } from "react"
 import { HVACCard } from "@/components/ui/hvac-card"
-import { cn } from "@/lib/utils"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { supabase } from "@/integrations/supabase/client"
 
 interface ModeSelectorProps {
   value: string
   onChange: (value: string) => void
 }
 
-const modes = [
-  { value: "residencial", label: "Residencial", description: "até 140%" },
-  { value: "corporativo", label: "Corporativo", description: "até 110%" },
-  { value: "maximo", label: "Capacidade Máxima"},
-]
+interface SimultOption {
+  nome: string
+  valor: number
+}
 
 export function ModeSelector({ value, onChange }: ModeSelectorProps) {
+  const [options, setOptions] = useState<SimultOption[]>([])
+  const [selected, setSelected] = useState<string>(value)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      const { data, error } = await supabase
+        .from('simultaneidade')
+        .select('nome, valor')
+        .order('nome', { ascending: true })
+
+      if (!active) return
+      if (error) {
+        console.error('Erro ao buscar simultaneidade:', error)
+        setOptions([
+          { nome: 'Corporativo', valor: 1.1 },
+          { nome: 'Residencial', valor: 1.4 },
+        ])
+        return
+      }
+
+      const list = (data || [])
+        .filter((r: any) => typeof r?.nome === 'string' && typeof r?.valor === 'number')
+        .map((r: any) => ({ nome: r.nome as string, valor: r.valor as number }))
+      setOptions(list)
+    }
+    load()
+    return () => { active = false }
+  }, [])
+
+  const residDefault = useMemo(() => {
+    const resid = options.find(o => o.nome.toLowerCase() === 'residencial')
+    return resid ? resid.valor.toString() : (options[0]?.valor?.toString() ?? '')
+  }, [options])
+
+  useEffect(() => {
+    if (!options.length) return
+
+    let next = value
+    const isNumeric = !Number.isNaN(parseFloat(value)) && value !== 'maximo'
+
+    if (value === 'residencial') {
+      next = residDefault
+    } else if (value === 'corporativo') {
+      const corp = options.find(o => o.nome.toLowerCase() === 'corporativo')
+      next = corp ? corp.valor.toString() : (isNumeric ? value : residDefault)
+    } else if (!isNumeric && value !== 'maximo') {
+      next = residDefault
+    }
+
+    setSelected(next)
+
+    if (next && next !== value) {
+      onChange(next)
+    }
+  }, [value, options, residDefault, onChange])
+
+  const handleChange = (val: string) => {
+    setSelected(val)
+    onChange(val)
+  }
+
   return (
     <HVACCard title="Modo de Simultaneidade" variant="warm">
-      <div className="space-y-3">
-        {modes.map((mode) => (
-          <label
-            key={mode.value}
-            className={cn(
-              "flex items-center justify-between p-3 rounded-lg border cursor-pointer transition-all",
-              "hover:bg-primary-warm/5 hover:border-primary-warm/30",
-              value === mode.value
-                ? "bg-primary-warm/10 border-primary-warm/50 text-primary-warm"
-                : "bg-background/30 border-border/50 text-foreground"
-            )}
-          >
-            <div className="flex items-center space-x-3">
-              <input
-                type="radio"
-                name="mode"
-                value={mode.value}
-                checked={value === mode.value}
-                onChange={(e) => onChange(e.target.value)}
-                className="sr-only"
-              />
-              <div className={cn(
-                "w-4 h-4 rounded-full border-2 flex items-center justify-center",
-                value === mode.value
-                  ? "border-primary-warm bg-primary-warm"
-                  : "border-border"
-              )}>
-                {value === mode.value && (
-                  <div className="w-2 h-2 rounded-full bg-background" />
-                )}
-              </div>
-              <div>
-                <div className="font-medium">{mode.label}</div>
-                <div className="text-xs text-muted-foreground">{mode.description}</div>
-              </div>
-            </div>
-          </label>
-        ))}
-      </div>
+      <Select value={selected} onValueChange={handleChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Selecione o modo" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt.nome} value={opt.valor.toString()}>
+              {`${opt.nome} (${Math.round(opt.valor * 100)}%)`}
+            </SelectItem>
+          ))}
+          <SelectItem value="maximo">Capacidade Máxima</SelectItem>
+        </SelectContent>
+      </Select>
     </HVACCard>
   )
 }

--- a/src/components/hvac/ModeSelector.tsx
+++ b/src/components/hvac/ModeSelector.tsx
@@ -83,11 +83,14 @@ export function ModeSelector({ value, onChange }: ModeSelectorProps) {
           <SelectValue placeholder="Selecione o modo" />
         </SelectTrigger>
         <SelectContent>
-          {options.map((opt) => (
-            <SelectItem key={opt.nome} value={opt.valor.toString()}>
-              {`${opt.nome} (${Math.round(opt.valor * 100)}%)`}
-            </SelectItem>
-          ))}
+          {options.map((opt) => {
+            const hidePercent = /capacidade|máxima|maxim/i.test(opt.nome)
+            return (
+              <SelectItem key={opt.nome} value={opt.valor.toString()}>
+                {hidePercent ? opt.nome : `${opt.nome} (${Math.round(opt.valor * 100)}%)`}
+              </SelectItem>
+            )
+          })}
           <SelectItem value="maximo"><span className="sr-only">Capacidade Máxima</span></SelectItem>
         </SelectContent>
       </Select>

--- a/src/utils/hvac-calculator.ts
+++ b/src/utils/hvac-calculator.ts
@@ -15,6 +15,9 @@ const soma = (arr: number[]): number => arr.reduce((t, n) => t + n, 0)
 
 export function capEfetiva(modelo: EvaporatorModel, modo: string): number {
   const { capNominal, capMax } = modelo
+  if (modo === 'maximo') return capMax
+  const factor = parseFloat(modo)
+  if (!Number.isNaN(factor)) return Math.min(capNominal * factor, capMax)
   if (modo === 'residencial') return Math.min(capNominal * 1.4, capMax)
   if (modo === 'corporativo') return Math.min(capNominal * 1.1, capMax)
   return capMax


### PR DESCRIPTION
## Purpose

The user requested to replace the existing multi-option "Modo de Simultaneidade" (Simultaneity Mode) menu with a single-selection dropdown that dynamically loads data from the Supabase database. The goal was to:

- Load simultaneity options from the database (nome and valor fields)
- Display options with percentage format (e.g., "Residencial (140%)")
- Set "Residencial" as the default selection
- Hide percentage description for "Capacidade Máxima" items
- Maintain compatibility with the existing calculation system

## Code changes

### ModeSelector.tsx
- **Replaced radio button interface** with Select dropdown component
- **Added dynamic data loading** from Supabase `simultaneidade` table
- **Implemented state management** for options and selected values
- **Added percentage formatting** for display names (except for "Capacidade Máxima")
- **Set default selection** to "Residencial" on load and clear
- **Added error handling** with fallback options

### hvac-calculator.ts
- **Enhanced capEfetiva function** to handle numeric mode values
- **Added dynamic factor calculation** using parseFloat for database values
- **Maintained backward compatibility** with existing string-based modes
- **Preserved "maximo" mode functionality** without multiplication

The changes maintain full compatibility with the existing HVAC calculation system while providing a more flexible, database-driven interface.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e40c2ca36174328a8c89d94d712d3af/curry-forge)

👀 [Preview Link](https://2e40c2ca36174328a8c89d94d712d3af-curry-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e40c2ca36174328a8c89d94d712d3af</projectId>-->
<!--<branchName>curry-forge</branchName>-->