### PR TITLE
Replace VRF simultaneity field with dynamic Postgres select

### DIFF
--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -165,6 +165,7 @@ export function VRFCondensadoraCalculator() {
     setEvaporators([]);
     setResults(null);
     setParams({ simultaneidade: 'corporativo', tipoCondensadora: 'vertical', evaporadora: 'hi-wall', quantidade: '1', nominal: '7' });
+    applyDefaultSimult(simultOptions);
   };
 
   // Recalcula automaticamente quando evaporators ou params de simultaneidade/orientação mudam

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -323,7 +323,7 @@ export function VRFCondensadoraCalculator() {
             {/* Resultado */}
           <div className="space-y-4">
             <h3 className="font-semibold text-sm">Resultado</h3>
-            <div className="flex gap-2 mb-4">
+            <div className="flex items-center gap-2 mb-4">
               <Button
                 variant={selectedBrand === "samsung" ? "default" : "outline"}
                 size="sm"
@@ -332,20 +332,19 @@ export function VRFCondensadoraCalculator() {
                 Samsung
               </Button>
 
-              <div className="flex flex-col items-start">
-                {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
-                  <div className="mb-2 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
-                    <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">Atenção: na Daikin o limite é 130%. Cálculo feito com 130%.</p>
-                  </div>
-                )}
-                <Button
-                  variant={selectedBrand === "daikin" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedBrand("daikin")}
-                >
-                  Daikin
-                </Button>
-              </div>
+              <Button
+                variant={selectedBrand === "daikin" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedBrand("daikin")}
+              >
+                Daikin
+              </Button>
+
+              {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
+                <div className="ml-2 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
+                  <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">Atenção: na Daikin o limite é 130%. Cálculo feito com 130%.</p>
+                </div>
+              )}
             </div>
             
             {results && evaporators.length > 0 ? (

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -168,10 +168,10 @@ export function VRFCondensadoraCalculator() {
     applyDefaultSimult(simultOptions);
   };
 
-  // Recalcula automaticamente quando evaporators ou params de simultaneidade/orientação mudam
+  // Recalcula automaticamente quando evaporators ou simultaneidade/orientação mudam
   useEffect(() => {
     recalculate();
-  }, [evaporators, params.simultaneidade, params.tipoCondensadora]);
+  }, [evaporators, form.simultaneidadeValor, params.tipoCondensadora]);
 
   // Recalcula evaporadores quando muda de marca
   useEffect(() => {

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -338,8 +338,7 @@ export function VRFCondensadoraCalculator() {
               <div className="space-y-3 text-sm">
                 {/* Alerta para 145% inválido em Vertical */}
                 {(() => {
-                  const simulRaw = params.simultaneidade === 'corporativo' ? 1.10 : params.simultaneidade === 'padrao' ? 1.30 : 1.45;
-                  const invalid145Vertical = Math.abs(simulRaw - 1.45) < 1e-6 && params.tipoCondensadora === 'vertical';
+                  const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
                   return invalid145Vertical;
                 })() && (
                   <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
@@ -351,8 +350,7 @@ export function VRFCondensadoraCalculator() {
 
                 {/* Warning for Daikin quando simultaneidade > 130% */}
                 {(() => {
-                  const simulRaw = params.simultaneidade === 'corporativo' ? 1.10 : params.simultaneidade === 'padrao' ? 1.30 : 1.45;
-                  return selectedBrand === 'daikin' && simulRaw > 1.30;
+                  return selectedBrand === 'daikin' && form.simultaneidadeValor > 130;
                 })() && (
                   <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
                     <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -324,15 +324,24 @@ export function VRFCondensadoraCalculator() {
           <div className="space-y-4">
             <h3 className="font-semibold text-sm">Resultado</h3>
             <div className="flex gap-2 mb-4">
-              <Button 
-                variant={selectedBrand === "samsung" ? "default" : "outline"} 
+              <Button
+                variant={selectedBrand === "samsung" ? "default" : "outline"}
                 size="sm"
                 onClick={() => setSelectedBrand("samsung")}
               >
                 Samsung
               </Button>
-              <Button 
-                variant={selectedBrand === "daikin" ? "default" : "outline"} 
+
+              {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
+                <div className="flex items-center">
+                  <div className="p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md mr-2">
+                    <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">Atenção: na Daikin o limite é 130%. Cálculo feito com 130%.</p>
+                  </div>
+                </div>
+              )}
+
+              <Button
+                variant={selectedBrand === "daikin" ? "default" : "outline"}
                 size="sm"
                 onClick={() => setSelectedBrand("daikin")}
               >

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { StatusChip } from '@/components/ui/status-chip';
 import { CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Thermometer, Settings } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
 import { calcularCondensadoraVRF } from '@/utils/vrf-calculator';
 import { evaporadoras } from '@/utils/evaporadoras';
 

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -368,11 +368,6 @@ export function VRFCondensadoraCalculator() {
                 Daikin
               </Button>
 
-              {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
-                <div className="ml-2 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
-                  <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">Atenção: na Daikin o limite é 130%. Cálculo feito com 130%.</p>
-                </div>
-              )}
             </div>
             
             {results && evaporators.length > 0 ? (

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -90,42 +90,36 @@ export function VRFCondensadoraCalculator() {
   const [viewMode, setViewMode] = useState<"unidades" | "agrupado">("agrupado");
 
   const recalculate = () => {
-    const simultaneidadeValues = {
-      corporativo: 110,
-      padrao: 130,
-      residencial: 145
-    };
-
     // Soma todas as evaporadoras (realBTU * qtd)
     const totalCapacity = evaporators.reduce((acc, ev) => acc + (ev.realBTU * ev.qtd), 0);
-    
+
     if (totalCapacity === 0) {
       setResults(null);
       return;
     }
-    
+
     const entrada = [totalCapacity];
-    const simultaneidadeRaw = simultaneidadeValues[params.simultaneidade as keyof typeof simultaneidadeValues];
-    
+    const simultaneidadeRaw = form.simultaneidadeValor || 110;
+
     // Para Samsung, usa a simultaneidade selecionada
     const simultaneidadeSamsung = simultaneidadeRaw;
-    
-    // Para Daikin, limita a 130% se for 145%
+
+    // Para Daikin, limita a 130% quando selecionado acima de 130%
     const simultaneidadeDaikin = simultaneidadeRaw > 130 ? 130 : simultaneidadeRaw;
-    
+
     // Calcula para ambas as marcas com suas respectivas simultaneidades
     const samsungResult = calcularCondensadoraVRF(entrada, simultaneidadeSamsung, "samsung", params.tipoCondensadora as any);
     const daikinResult = calcularCondensadoraVRF(entrada, simultaneidadeDaikin, "daikin", params.tipoCondensadora as any);
 
     setResults({
-      samsung: { 
-        ...samsungResult, 
+      samsung: {
+        ...samsungResult,
         orientacao: params.tipoCondensadora,
         simultaneidadeUsada: simultaneidadeSamsung,
         simultaneidadeSelecionada: simultaneidadeRaw
       },
-      daikin: { 
-        ...daikinResult, 
+      daikin: {
+        ...daikinResult,
         orientacao: params.tipoCondensadora,
         simultaneidadeUsada: simultaneidadeDaikin,
         simultaneidadeSelecionada: simultaneidadeRaw

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -226,8 +226,7 @@ export function VRFCondensadoraCalculator() {
             </div>
             {/* Alerta para 145% inválido em Vertical */}
             {(() => {
-              const simulRaw = params.simultaneidade === 'corporativo' ? 1.10 : params.simultaneidade === 'padrao' ? 1.30 : 1.45;
-              const invalid145Vertical = Math.abs(simulRaw - 1.45) < 1e-6 && params.tipoCondensadora === 'vertical';
+              const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
               if (!invalid145Vertical) return null;
               return (
                 <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -50,6 +50,12 @@ export function VRFCondensadoraCalculator() {
     setForm({ simultaneidade: def, simultaneidadeValor: def.valor });
   }
 
+  const getSimultPercent = () => {
+    const v = form.simultaneidadeValor;
+    if (v == null) return 110;
+    return v > 10 ? Math.round(v) : Math.round(v * 100);
+  };
+
   useEffect(() => {
     let active = true;
     async function load() {
@@ -226,7 +232,7 @@ export function VRFCondensadoraCalculator() {
             </div>
             {/* Alerta para 145% inválido em Vertical */}
             {(() => {
-              const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
+              const invalid145Vertical = getSimultPercent() === 145 && params.tipoCondensadora === 'vertical';
               if (!invalid145Vertical) return null;
               return (
                 <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
@@ -338,7 +344,7 @@ export function VRFCondensadoraCalculator() {
               <div className="space-y-3 text-sm">
                 {/* Alerta para 145% inválido em Vertical */}
                 {(() => {
-                  const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
+                  const invalid145Vertical = getSimultPercent() === 145 && params.tipoCondensadora === 'vertical';
                   return invalid145Vertical;
                 })() && (
                   <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
@@ -350,7 +356,7 @@ export function VRFCondensadoraCalculator() {
 
                 {/* Warning for Daikin quando simultaneidade > 130% */}
                 {(() => {
-                  return selectedBrand === 'daikin' && form.simultaneidadeValor > 130;
+                  return selectedBrand === 'daikin' && getSimultPercent() > 130;
                 })() && (
                   <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
                     <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">
@@ -422,7 +428,7 @@ export function VRFCondensadoraCalculator() {
                 <p><strong>Marca:</strong> {results[selectedBrand].marca}</p>
                 <p><strong>Simultaneidade (selecionada):</strong> {form.simultaneidadeValor}%
                   {(() => {
-                    const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
+                    const invalid145Vertical = getSimultPercent() === 145 && params.tipoCondensadora === 'vertical';
                     return invalid145Vertical ? (
                       <span className="ml-2 inline-flex items-center rounded-md bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-xs font-medium text-red-800 dark:text-red-200">
                         INVÁLIDA p/ Vertical

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -332,21 +332,20 @@ export function VRFCondensadoraCalculator() {
                 Samsung
               </Button>
 
-              {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
-                <div className="flex items-center">
-                  <div className="p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md mr-2">
+              <div className="flex flex-col items-start">
+                {selectedBrand === 'daikin' && getSimultPercent() === 145 && (
+                  <div className="mb-2 p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
                     <p className="text-amber-800 dark:text-amber-200 text-sm font-medium">Atenção: na Daikin o limite é 130%. Cálculo feito com 130%.</p>
                   </div>
-                </div>
-              )}
-
-              <Button
-                variant={selectedBrand === "daikin" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setSelectedBrand("daikin")}
-              >
-                Daikin
-              </Button>
+                )}
+                <Button
+                  variant={selectedBrand === "daikin" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setSelectedBrand("daikin")}
+                >
+                  Daikin
+                </Button>
+              </div>
             </div>
             
             {results && evaporators.length > 0 ? (

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -420,10 +420,9 @@ export function VRFCondensadoraCalculator() {
             <div className="grid grid-cols-2 gap-4 text-sm mb-4">
               <div>
                 <p><strong>Marca:</strong> {results[selectedBrand].marca}</p>
-                <p><strong>Simultaneidade (selecionada):</strong> {params.simultaneidade === 'corporativo' ? '110%' : params.simultaneidade === 'padrao' ? '130%' : '145%'}
+                <p><strong>Simultaneidade (selecionada):</strong> {form.simultaneidadeValor}%
                   {(() => {
-                    const simulRaw = params.simultaneidade === 'corporativo' ? 1.10 : params.simultaneidade === 'padrao' ? 1.30 : 1.45;
-                    const invalid145Vertical = Math.abs(simulRaw - 1.45) < 1e-6 && params.tipoCondensadora === 'vertical';
+                    const invalid145Vertical = form.simultaneidadeValor === 145 && params.tipoCondensadora === 'vertical';
                     return invalid145Vertical ? (
                       <span className="ml-2 inline-flex items-center rounded-md bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-xs font-medium text-red-800 dark:text-red-200">
                         INVÁLIDA p/ Vertical
@@ -431,8 +430,7 @@ export function VRFCondensadoraCalculator() {
                     ) : null;
                   })()}
                   {(() => {
-                    const simulRaw = params.simultaneidade === 'corporativo' ? 1.10 : params.simultaneidade === 'padrao' ? 1.30 : 1.45;
-                    return selectedBrand === 'daikin' && simulRaw > 1.30 ? (
+                    return selectedBrand === 'daikin' && form.simultaneidadeValor > 130 ? (
                       <span className="text-amber-600 dark:text-amber-400 text-xs ml-2">Capado p/ 130%</span>
                     ) : null;
                   })()}

--- a/src/components/hvac/VRFCondensadoraCalculator.tsx
+++ b/src/components/hvac/VRFCondensadoraCalculator.tsx
@@ -199,21 +199,30 @@ export function VRFCondensadoraCalculator() {
           <div className="space-y-4">
             <h3 className="font-semibold text-sm">Simultaneidade</h3>
             <div className="space-y-2">
-              {[
-                { value: 'corporativo', label: 'Corporativo (110%)', selected: params.simultaneidade === 'corporativo' },
-                { value: 'padrao', label: 'Limite Padrão (130%)', selected: params.simultaneidade === 'padrao' },
-                { value: 'residencial', label: 'Limite Residencial (145%)', selected: params.simultaneidade === 'residencial' }
-              ].map((option) => (
-                <Button
-                  key={option.value}
-                  variant={option.selected ? "default" : "outline"}
-                  size="sm"
-                  className="w-full justify-start"
-                  onClick={() => setParams(prev => ({ ...prev, simultaneidade: option.value }))}
-                >
-                  {option.label}
-                </Button>
-              ))}
+              <Select
+                value={form.simultaneidade ? String(form.simultaneidade.id) : ''}
+                onValueChange={(value) => {
+                  const opt = simultOptions.find(o => String(o.id) === value) || null;
+                  if (opt) {
+                    setForm({ simultaneidade: opt, simultaneidadeValor: opt.valor });
+                  }
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={simultLoading ? 'Carregando...' : 'Selecione'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {simultOptions.map((opt) => (
+                    <SelectItem key={opt.id} value={String(opt.id)}>{opt.nome}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {form.simultaneidade && (
+                <p className="text-xs text-muted-foreground">Fator: {form.simultaneidade.nome} (×{form.simultaneidadeValor})</p>
+              )}
+              {simultError && (
+                <p className="text-xs text-red-600 dark:text-red-400">{simultError}</p>
+              )}
             </div>
             {/* Alerta para 145% inválido em Vertical */}
             {(() => {


### PR DESCRIPTION
## Purpose

Replace the hardcoded simultaneity options in the VRF menu with a dynamic select component populated from a PostgreSQL database. The user requested to:
- Load simultaneity options from `public.simultaneidade_vrf` table
- Use a select dropdown with proper labeling and value handling
- Set default selection to "Corporativo" options (highest value if multiple)
- Store both the selected option and its numeric value for calculations
- Display helpful information and error handling

## Code changes

- **Database integration**: Added Supabase client import and query to fetch simultaneity options from `public.simultaneidade_vrf` table
- **State management**: Replaced hardcoded simultaneity params with dynamic form state containing `simultaneidade` object and `simultaneidadeValor` number
- **UI component**: Replaced button group with Select component that displays option names and stores IDs as values
- **Default selection logic**: Implemented function to automatically select "Corporativo" option with highest value on load and reset
- **Helper text**: Added display of current factor with format "Fator: {nome} (×{valor})"
- **Error handling**: Added loading states and error messages for database fetch failures
- **Calculation updates**: Modified recalculation logic to use `form.simultaneidadeValor` instead of hardcoded values
- **Validation**: Updated 145% vertical orientation warnings to use dynamic simultaneity valueTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e40c2ca36174328a8c89d94d712d3af/pixel-world)

👀 [Preview Link](https://2e40c2ca36174328a8c89d94d712d3af-pixel-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e40c2ca36174328a8c89d94d712d3af</projectId>-->
<!--<branchName>pixel-world</branchName>-->